### PR TITLE
lichess movelist childrens renamed fix

### DIFF
--- a/src/grabbers/lichess_grabber.py
+++ b/src/grabbers/lichess_grabber.py
@@ -73,7 +73,7 @@ class LichessGrabber(Grabber):
         children = None
         try:
             if not puzzles:
-                children = move_list_elem.find_elements(By.TAG_NAME, "u8t")
+                children = move_list_elem.find_elements(By.TAG_NAME, "xau")
             else:
                 children = move_list_elem.find_elements(By.TAG_NAME, "move")
         except NoSuchElementException:


### PR DESCRIPTION
The move_list child elements' tags have been renamed from u8t to xau, so the bot stopped playing. This PR is supposed to fix this.
Later on, the tag name should be retrieved dynamically in my opinion.
Eg:
```python
last_child = move_list_elem.find_elements(By.XPATH, "*[last()]")
tag_name = last_child[0].tag_name

# ... use it ...
```