### PR TITLE
[lichess improvements, changeable depth] sending moves via websocket, fixes, improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,27 @@ Note that the mouse is being moved by python
 **Note** You can stop the bot at any time by pressing Stop or pressing 2.
 
 ## Currently supports
-- [x] Windows/Linux platforms
-- [x] Chess.com
-- [x] Lichess.org
-- [x] Playing vs humans
-- [x] Playing vs bots
-- [x] Lichess puzzles (with option for non-stop solving)
-- [x] Manual mode (Press or hold 3 to move when enabled)  
+- Windows/Linux platforms
+- Chess.com
+- Lichess.org
+- Playing vs humans
+- Playing vs bots
+- Puzzles (with option for non-stop solving):
+    - [ ] chess.com
+    - [x] lichess.org
+- Manual mode (Press or hold 3 to move when enabled)  
   An arrow with the best move is also displayed
-- [x] Bongcloud mode ( ͡° ͜ʖ ͡° )
-- [x] Skill level selection (0-20)
-- [x] Memory (RAM) usage selection
-- [x] CPU threads number selection
-- [x] Slow Mover option (defaults to 100, 10 &le; Slow Mover &le; 1000)  
+- Mouseless mode (The moves are made without the mouse moving, also works while the browser is at the background):
+    - [ ] chess.com
+    - [x] lichess.org
+- Bongcloud mode ( ͡° ͜ʖ ͡° )
+- Skill level selection (0-20)
+- Depth level selection (1-20)
+- Memory (RAM) usage selection
+- CPU threads number selection
+- Slow Mover option (defaults to 100, 10 &le; Slow Mover &le; 1000)  
   lower values will make Stockfish take less time in games, higher values will make it think longer
-- [x] Exporting finished games to PGN
+- Exporting finished games to PGN
 
 ## Disclaimer
 Under no circumstances should you use this bot to cheat in online games or tournaments. This bot was made for educational purposes only.

--- a/src/grabbers/chesscom_grabber.py
+++ b/src/grabbers/chesscom_grabber.py
@@ -136,3 +136,6 @@ class ChesscomGrabber(Grabber):
 
     def click_puzzle_next(self):
         pass
+
+    def make_mouseless_move(self, move, move_count):
+        pass

--- a/src/grabbers/grabber.py
+++ b/src/grabbers/grabber.py
@@ -51,3 +51,8 @@ class Grabber(ABC):
     @abstractmethod
     def click_puzzle_next(self):
         pass
+
+    # Makes a mouseless move
+    @abstractmethod
+    def make_mouseless_move(self, move, move_count):
+        pass

--- a/src/grabbers/lichess_grabber.py
+++ b/src/grabbers/lichess_grabber.py
@@ -60,18 +60,13 @@ class LichessGrabber(Grabber):
 
         move_list_elem = self.get_normal_move_list_elem()
 
-        if move_list_elem is None or not move_list_elem:
+        if move_list_elem is None or move_list_elem == []:
             return False
 
         try:
             last_child = move_list_elem.find_element(By.XPATH, "*[last()]")
-            tag = last_child.tag_name
+            self.tag_name = last_child.tag_name
 
-            # If the tag is div then the game has not started yet
-            if tag == "div":
-                return False
-
-            self.tag_name = tag
             return True
         except NoSuchElementException:
             return False
@@ -129,10 +124,10 @@ class LichessGrabber(Grabber):
         except NoSuchElementException:
             try:
                 # Try finding the normal move list when there are no moves yet
-                move_list_elem = self.chrome.find_element(By.XPATH, '//*[@id="main-wrap"]/main/div[1]/rm6')
+                self.chrome.find_element(By.XPATH, '//*[@id="main-wrap"]/main/div[1]/rm6')
 
                 # If we don't have an exception at this point, we don't have any moves yet
-                return move_list_elem
+                return []
             except NoSuchElementException:
                 return None
 

--- a/src/grabbers/lichess_grabber.py
+++ b/src/grabbers/lichess_grabber.py
@@ -104,3 +104,8 @@ class LichessGrabber(Grabber):
 
         # Click the continue training button
         self.chrome.execute_script("arguments[0].click();", next_button)
+
+    def ws_execute_move(self, move):
+        message = '{"t":"move","d":{"u":"' + move + '","b":1,"a":' + move_count + '}}'
+        script = 'lichess.socket.ws.send(JSON.stringify(' + message + '))'
+        self.chrome.execute_script(script)

--- a/src/grabbers/lichess_grabber.py
+++ b/src/grabbers/lichess_grabber.py
@@ -106,6 +106,6 @@ class LichessGrabber(Grabber):
         self.chrome.execute_script("arguments[0].click();", next_button)
 
     def ws_execute_move(self, move):
-        message = '{"t":"move","d":{"u":"' + move + '","b":1,"a":' + move_count + '}}'
+        message = '{"t":"move","d":{"u":"' + move + '","b":1,"a":' + str(move_count) + '}}'
         script = 'lichess.socket.ws.send(JSON.stringify(' + message + '))'
         self.chrome.execute_script(script)

--- a/src/gui.py
+++ b/src/gui.py
@@ -67,15 +67,18 @@ class GUI:
 
         # Create the website chooser radio buttons
         self.website = tk.StringVar(value="chesscom")
-        self.chesscom_radio_button = tk.Radiobutton(left_frame, text="Chess.com", variable=self.website, value="chesscom")
+        self.chesscom_radio_button = tk.Radiobutton(left_frame, text="Chess.com", variable=self.website,
+                                                    value="chesscom")
         self.chesscom_radio_button.pack(anchor=tk.NW)
-        self.lichess_radio_button = tk.Radiobutton(left_frame, text="Lichess.org", variable=self.website, value="lichess")
+        self.lichess_radio_button = tk.Radiobutton(left_frame, text="Lichess.org", variable=self.website,
+                                                   value="lichess")
         self.lichess_radio_button.pack(anchor=tk.NW)
 
         # Create the open browser button
         self.opening_browser = False
         self.opened_browser = False
-        self.open_browser_button = tk.Button(left_frame, text="Open Browser", command=self.on_open_browser_button_listener)
+        self.open_browser_button = tk.Button(left_frame, text="Open Browser",
+                                             command=self.on_open_browser_button_listener)
         self.open_browser_button.pack(anchor=tk.NW)
 
         # Create the start button
@@ -86,7 +89,8 @@ class GUI:
 
         # Create the manual mode checkbox
         self.enable_manual_mode = tk.BooleanVar(value=False)
-        self.manual_mode_checkbox = tk.Checkbutton(left_frame, text="Manual Mode", variable=self.enable_manual_mode, command=self.on_manual_mode_checkbox_listener)
+        self.manual_mode_checkbox = tk.Checkbutton(left_frame, text="Manual Mode", variable=self.enable_manual_mode,
+                                                   command=self.on_manual_mode_checkbox_listener)
         self.manual_mode_checkbox.pack(anchor=tk.NW)
 
         # Create the manual mode instructions
@@ -94,14 +98,21 @@ class GUI:
         self.manual_mode_label = tk.Label(self.manual_mode_frame, text="\u2022 Press 3 to make a move")
         self.manual_mode_label.pack(anchor=tk.NW)
 
+        # Create the mouseless mode checkbox
+        self.enable_mouseless_mode = tk.BooleanVar(value=False)
+        self.mouseless_mode_checkbox = tk.Checkbutton(left_frame, text="Mouseless Mode",
+                                                      variable=self.enable_mouseless_mode)
+        self.mouseless_mode_checkbox.pack(anchor=tk.NW)
+
         # Create the non-stop puzzles check button
         self.enable_non_stop_puzzles = tk.IntVar(value=0)
-        self.non_stop_puzzles_check_button = tk.Checkbutton(left_frame, text="Non-stop puzzles", variable=self.enable_non_stop_puzzles)
+        self.non_stop_puzzles_check_button = tk.Checkbutton(left_frame, text="Non-stop puzzles",
+                                                            variable=self.enable_non_stop_puzzles)
         self.non_stop_puzzles_check_button.pack(anchor=tk.NW)
 
         # Create the bongcloud check button
         self.enable_bongcloud = tk.IntVar()
-        self.bongcloud_check_button = tk.Checkbutton(left_frame, text='Bongcloud', variable=self.enable_bongcloud, onvalue=1, offvalue=0)
+        self.bongcloud_check_button = tk.Checkbutton(left_frame, text='Bongcloud', variable=self.enable_bongcloud)
         self.bongcloud_check_button.pack(anchor=tk.NW)
 
         # Separator
@@ -123,9 +134,10 @@ class GUI:
 
         # Create the skill level scale
         skill_level_frame = tk.Frame(left_frame)
-        tk.Label(skill_level_frame, text="Skill Level").pack(side=tk.LEFT, pady=19)
+        tk.Label(skill_level_frame, text="Skill Level").pack(side=tk.LEFT, pady=(19, 0))
         self.skill_level = tk.IntVar(value=20)
-        self.skill_level_scale = tk.Scale(skill_level_frame, from_=0, to=20, orient=tk.HORIZONTAL, variable=self.skill_level)
+        self.skill_level_scale = tk.Scale(skill_level_frame, from_=0, to=20, orient=tk.HORIZONTAL,
+                                          variable=self.skill_level)
         self.skill_level_scale.pack()
         skill_level_frame.pack(anchor=tk.NW)
 
@@ -165,12 +177,14 @@ class GUI:
 
         # Create the topmost check button
         self.enable_topmost = tk.IntVar(value=1)
-        self.topmost_check_button = tk.Checkbutton(left_frame, text='Window stays on top', variable=self.enable_topmost, onvalue=1, offvalue=0, command=self.on_topmost_check_button_listener)
+        self.topmost_check_button = tk.Checkbutton(left_frame, text='Window stays on top', variable=self.enable_topmost,
+                                                   onvalue=1, offvalue=0, command=self.on_topmost_check_button_listener)
         self.topmost_check_button.pack(anchor=tk.NW)
 
         # Create the select stockfish button
         self.stockfish_path = ""
-        self.select_stockfish_button = tk.Button(left_frame, text="Select Stockfish", command=self.on_select_stockfish_button_listener)
+        self.select_stockfish_button = tk.Button(left_frame, text="Select Stockfish",
+                                                 command=self.on_select_stockfish_button_listener)
         self.select_stockfish_button.pack(anchor=tk.NW)
 
         # Create the stockfish path text
@@ -186,7 +200,8 @@ class GUI:
         treeview_frame = tk.Frame(right_frame)
 
         # Create the moves Treeview
-        self.tree = ttk.Treeview(treeview_frame, column=("#", "White", "Black"), show='headings', height=23, selectmode='browse')
+        self.tree = ttk.Treeview(treeview_frame, column=("#", "White", "Black"), show='headings', height=23,
+                                 selectmode='browse')
         self.tree.pack(anchor=tk.NW, side=tk.LEFT)
 
         # # Add the scrollbar to the Treeview
@@ -248,7 +263,8 @@ class GUI:
     def browser_checker_thread(self):
         while not self.exit:
             try:
-                if self.opened_browser and self.chrome is not None and "target window already closed" in self.chrome.get_log('driver')[-1]["message"]:
+                if self.opened_browser and self.chrome is not None and "target window already closed" in \
+                        self.chrome.get_log('driver')[-1]["message"]:
                     self.opened_browser = False
 
                     # Set Opening Browser button state to closed
@@ -391,6 +407,11 @@ class GUI:
             tk.messagebox.showerror("Error", "Stockfish path is empty")
             return
 
+        # Check if mouseless mode is enabled when on chess.com
+        if self.enable_mouseless_mode.get() == 1 and self.website.get() == "chesscom":
+            tk.messagebox.showerror("Error", "Mouseless mode is only supported on lichess.org")
+            return
+
         # Create the pipes used for the communication
         # between the GUI and the Stockfish Bot process
         parent_conn, child_conn = multiprocess.Pipe()
@@ -401,8 +422,22 @@ class GUI:
         st_ov_queue = multiprocess.Queue()
 
         # Create the Stockfish Bot process
-        self.stockfish_bot_process = StockfishBot(self.chrome_url, self.chrome_session_id, self.website.get(), child_conn, st_ov_queue, self.stockfish_path, self.enable_manual_mode.get() == 1, self.enable_non_stop_puzzles.get() == 1,
-                                                  self.enable_bongcloud.get() == 1, self.slow_mover.get(), self.skill_level.get(), self.stockfish_depth.get(), self.memory.get(), self.cpu_threads.get())
+        self.stockfish_bot_process = StockfishBot(
+            self.chrome_url,
+            self.chrome_session_id,
+            self.website.get(),
+            child_conn, st_ov_queue,
+            self.stockfish_path,
+            self.enable_manual_mode.get() == 1,
+            self.enable_mouseless_mode.get() == 1,
+            self.enable_non_stop_puzzles.get() == 1,
+            self.enable_bongcloud.get() == 1,
+            self.slow_mover.get(),
+            self.skill_level.get(),
+            self.stockfish_depth.get(),
+            self.memory.get(),
+            self.cpu_threads.get()
+        )
         self.stockfish_bot_process.start()
 
         # Create the overlay
@@ -456,7 +491,8 @@ class GUI:
 
     def on_export_pgn_button_listener(self):
         # Create the file dialog
-        f = filedialog.asksaveasfile(initialfile='match.pgn', defaultextension=".pgn", filetypes=[("Portable Game Notation", "*.pgn"), ("All Files", "*.*")])
+        f = filedialog.asksaveasfile(initialfile='match.pgn', defaultextension=".pgn",
+                                     filetypes=[("Portable Game Notation", "*.pgn"), ("All Files", "*.*")])
         if f is None:
             return
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -129,6 +129,15 @@ class GUI:
         self.skill_level_scale.pack()
         skill_level_frame.pack(anchor=tk.NW)
 
+        # Create the Stockfish depth scale
+        stockfish_depth_frame = tk.Frame(left_frame)
+        tk.Label(stockfish_depth_frame, text="Depth").pack(side=tk.LEFT, pady=19)
+        self.stockfish_depth = tk.IntVar(value=15)
+        self.stockfish_depth_scale = tk.Scale(stockfish_depth_frame, from_=1, to=20, orient=tk.HORIZONTAL,
+                                              variable=self.stockfish_depth)
+        self.stockfish_depth_scale.pack()
+        stockfish_depth_frame.pack(anchor=tk.NW)
+
         # Create the memory entry field
         memory_frame = tk.Frame(left_frame)
         tk.Label(memory_frame, text="Memory").pack(side=tk.LEFT)
@@ -393,7 +402,7 @@ class GUI:
 
         # Create the Stockfish Bot process
         self.stockfish_bot_process = StockfishBot(self.chrome_url, self.chrome_session_id, self.website.get(), child_conn, st_ov_queue, self.stockfish_path, self.enable_manual_mode.get() == 1, self.enable_non_stop_puzzles.get() == 1,
-                                                  self.enable_bongcloud.get() == 1, self.slow_mover.get(), self.skill_level.get(), self.memory.get(), self.cpu_threads.get())
+                                                  self.enable_bongcloud.get() == 1, self.slow_mover.get(), self.skill_level.get(), self.stockfish_depth.get(), self.memory.get(), self.cpu_threads.get())
         self.stockfish_bot_process.start()
 
         # Create the overlay

--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -208,7 +208,10 @@ class StockfishBot(multiprocess.Process):
                         stockfish.make_moves_from_current_position([move])
                         move_list.append(move_san)
                         self.grabber.ws_execute_move(move, move_count + 1)
-                        # self.make_move(move)
+                        if self.website == "lichess":
+                            self.grabber.ws_execute_move(move, move_count + 1)
+                        else:
+                            self.make_move(move)
 
                     self.overlay_queue.put([])
 

--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -207,7 +207,7 @@ class StockfishBot(multiprocess.Process):
                         board.push_uci(move)
                         stockfish.make_moves_from_current_position([move])
                         move_list.append(move_san)
-                        if self.website == "lichess":
+                        if self.website == "lichess" and not self.grabber.is_game_puzzles():
                             self.grabber.ws_execute_move(move, move_count + 1)
                         else:
                             self.make_move(move)

--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -207,7 +207,6 @@ class StockfishBot(multiprocess.Process):
                         board.push_uci(move)
                         stockfish.make_moves_from_current_position([move])
                         move_list.append(move_san)
-                        self.grabber.ws_execute_move(move, move_count + 1)
                         if self.website == "lichess":
                             self.grabber.ws_execute_move(move, move_count + 1)
                         else:

--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -207,7 +207,8 @@ class StockfishBot(multiprocess.Process):
                         board.push_uci(move)
                         stockfish.make_moves_from_current_position([move])
                         move_list.append(move_san)
-                        self.make_move(move)
+                        self.grabber.ws_execute_move(move, move_count + 1)
+                        # self.make_move(move)
 
                     self.overlay_queue.put([])
 

--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -15,7 +15,7 @@ import keyboard
 
 
 class StockfishBot(multiprocess.Process):
-    def __init__(self, chrome_url, chrome_session_id, website, pipe, overlay_queue, stockfish_path, enable_manual_mode, enable_non_stop_puzzles, bongcloud, slow_mover, skill_level, stockfish_depth, memory, cpu_threads):
+    def __init__(self, chrome_url, chrome_session_id, website, pipe, overlay_queue, stockfish_path, enable_manual_mode, enable_mouseless_mode, enable_non_stop_puzzles, bongcloud, slow_mover, skill_level, stockfish_depth, memory, cpu_threads):
         multiprocess.Process.__init__(self)
 
         self.chrome_url = chrome_url
@@ -25,6 +25,7 @@ class StockfishBot(multiprocess.Process):
         self.overlay_queue = overlay_queue
         self.stockfish_path = stockfish_path
         self.enable_manual_mode = enable_manual_mode
+        self.enable_mouseless_mode = enable_mouseless_mode
         self.enable_non_stop_puzzles = enable_non_stop_puzzles
         self.bongcloud = bongcloud
         self.slow_mover = slow_mover
@@ -208,8 +209,8 @@ class StockfishBot(multiprocess.Process):
                         board.push_uci(move)
                         stockfish.make_moves_from_current_position([move])
                         move_list.append(move_san)
-                        if self.website == "lichess" and not self.grabber.is_game_puzzles():
-                            self.grabber.ws_execute_move(move, move_count + 1)
+                        if self.enable_mouseless_mode and not self.grabber.is_game_puzzles():
+                            self.grabber.make_mouseless_move(move, move_count + 1)
                         else:
                             self.make_move(move)
 

--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -15,7 +15,7 @@ import keyboard
 
 
 class StockfishBot(multiprocess.Process):
-    def __init__(self, chrome_url, chrome_session_id, website, pipe, overlay_queue, stockfish_path, enable_manual_mode, enable_non_stop_puzzles, bongcloud, slow_mover, skill_level, memory, cpu_threads):
+    def __init__(self, chrome_url, chrome_session_id, website, pipe, overlay_queue, stockfish_path, enable_manual_mode, enable_non_stop_puzzles, bongcloud, slow_mover, skill_level, stockfish_depth, memory, cpu_threads):
         multiprocess.Process.__init__(self)
 
         self.chrome_url = chrome_url
@@ -29,6 +29,7 @@ class StockfishBot(multiprocess.Process):
         self.bongcloud = bongcloud
         self.slow_mover = slow_mover
         self.skill_level = skill_level
+        self.stockfish_depth = stockfish_depth
         self.grabber = None
         self.memory = memory
         self.cpu_threads = cpu_threads
@@ -108,7 +109,7 @@ class StockfishBot(multiprocess.Process):
             "Skill Level": self.skill_level
         }
         try:
-            stockfish = Stockfish(path=self.stockfish_path, parameters=parameters)
+            stockfish = Stockfish(path=self.stockfish_path, depth=self.stockfish_depth, parameters=parameters)
         except PermissionError:
             self.pipe.send("ERR_PERM")
             return


### PR DESCRIPTION
- Added the possibility to send the bot's moves via Lichess' built-in websocket client.
	- This way the bot can run even in the background or on a second monitor, it won't move the mouse, so you can enjoy other things while the bot is playing for you.
	- Currently only works for Lichess.
	- **Doesn't work in Puzzles** as Puzzles don't send network data via websocket.

- Fixed `is_game_over()` not working with locales other than English.
- Fixed `click_puzzle_next()` not working when a specific "Continue training" button comes up when Lichess wants you to rate the puzzle.
- Improved `get_move_list()`
	- Extracted the code part that finds the `move_list_elem` element into getters. One getter for normal games, one getter for puzzles.
	- Fixed circlejerking trying to figure out whether we are playing puzzles or not while we already have a `is_game_puzzles()` method that can check it.
	- Added a `set_moves_tag_name()` method that dynamically gets the element's tag name from the site that contains the moves. Ref:
		- https://github.com/PanagiotisIatrou/chess-auto-bot/issues/7
		- https://github.com/PanagiotisIatrou/chess-auto-bot/pull/11
- Stockfish's depth can be changed now. The default is 15, the minimum is 1, the maximum is 20.