### PR TITLE
[performance fix] move caching

### DIFF
--- a/src/stockfish_bot.py
+++ b/src/stockfish_bot.py
@@ -233,7 +233,7 @@ class StockfishBot(multiprocess.Process):
                 # Wait for a response from the opponent
                 # by finding the differences between
                 # the previous and current position
-                previous_move_list = move_list
+                previous_move_list = move_list.copy()
                 while True:
                     if self.grabber.is_game_over():
                         # Send restart message to GUI


### PR DESCRIPTION
I've implemented move-caching both for Lichess and Chess.com.

Every move is now stored in a dictionary, and we are only querying the newly added moves from the DOM. This way when we have to process the moves, we only have to deal with the new moves, gaining a huge speed boost.
This is most noticeable at high move count games.

From my testings, on Chess.com, after 15-ish moves, the delay caused by getting every single move from the DOM and processing them all over every time was over 1 second. At 20-ish moves, it was already 1.8-2+ seconds. This is an unacceptable delay in 1min Bullet, for example.

With these changes, getting and processing the moves was under 0.2s at every stage of the game.

Feel free to test it and if you like the changes, you can merge it.